### PR TITLE
Fix homepage entry in cabal file

### DIFF
--- a/RBTree.cabal
+++ b/RBTree.cabal
@@ -2,7 +2,7 @@ Name:              RBTree
 Version:           0.0.5
 Synopsis:          Pure haskell Red-Black-Tree implemetation
 Description:       This package implemets Red-Black tree data-structure.
-homepage:          git://github.com/wuxb45/Haskell-RBTree.git
+homepage:          https://github.com/wuxb45/Haskell-RBTree
 License:           BSD3
 License-file:      LICENSE
 Author:            Wu Xingbo


### PR DESCRIPTION
I stumbled upon your package at https://hackage.haskell.org/package/RBTree and blindly clicked the homepage link which did not work. Upon closer inspection I could see you had entered a uri for your git repository.